### PR TITLE
Replace outdated constant TYPO3_branch with Typo3Version class

### DIFF
--- a/Classes/Compatibility.php
+++ b/Classes/Compatibility.php
@@ -1,19 +1,21 @@
 <?php declare(strict_types=1);
 namespace T3\Min;
 
-use TYPO3\CMS\Core\Utility\VersionNumberUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Information\Typo3Version;
 
 class Compatibility
 {
-    /**
-     * Checks if current TYPO3 version is 10.0.0 or greater (by default)
-     *
-     * @param string $version e.g. 10.0.0
-     * @return bool
-     */
-    public static function isTypo3Version($version = '10.0.0') : bool
-    {
-        return VersionNumberUtility::convertVersionNumberToInteger(TYPO3_branch) >=
-            VersionNumberUtility::convertVersionNumberToInteger($version);
-    }
+	/**
+	 * Checks if current TYPO3 version is 10.0.0 or greater (by default)
+	 *
+	 * @param string $version e.g. 10.0.0
+	 * @return bool
+	 */
+	public static function isTypo3Version($version = '10') : bool
+	{
+		$typo3Version = GeneralUtility::makeInstance(Typo3Version::class);
+		return $typo3Version->getMajorVersion() >=
+		       explode('.', $version)[0];
+	}
 }

--- a/Resources/Private/PHP/composer.lock
+++ b/Resources/Private/PHP/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "matthiasmullie/minify",
-            "version": "1.3.68",
+            "version": "1.3.69",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matthiasmullie/minify.git",
-                "reference": "c00fb02f71b2ef0a5f53fe18c5a8b9aa30f48297"
+                "reference": "a61c949cccd086808063611ef9698eabe42ef22f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matthiasmullie/minify/zipball/c00fb02f71b2ef0a5f53fe18c5a8b9aa30f48297",
-                "reference": "c00fb02f71b2ef0a5f53fe18c5a8b9aa30f48297",
+                "url": "https://api.github.com/repos/matthiasmullie/minify/zipball/a61c949cccd086808063611ef9698eabe42ef22f",
+                "reference": "a61c949cccd086808063611ef9698eabe42ef22f",
                 "shasum": ""
             },
             "require": {
@@ -66,7 +66,7 @@
             ],
             "support": {
                 "issues": "https://github.com/matthiasmullie/minify/issues",
-                "source": "https://github.com/matthiasmullie/minify/tree/1.3.68"
+                "source": "https://github.com/matthiasmullie/minify/tree/1.3.69"
             },
             "funding": [
                 {
@@ -74,7 +74,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-19T08:28:56+00:00"
+            "time": "2022-08-01T09:00:18+00:00"
         },
         {
             "name": "matthiasmullie/path-converter",


### PR DESCRIPTION
This PR replaces the removed `TYPO3_branch` by utilizing the introduced `\TYPO3\CMS\Core\Information\Typo3Version` class. Feel free to make the explode prettier