### PR TITLE
Check if asset is already processed

### DIFF
--- a/Classes/Minifier.php
+++ b/Classes/Minifier.php
@@ -73,6 +73,8 @@ class Minifier
                 $filesAfterCompression[$key] = $config;
                 continue;
             }
+            // Do not proceed, if asset already minified/gzipped
+            if (preg_match("/(?:-min\.)|(\.gz$)/", $config['file'])) continue;
 
             // If key "code" is existing, this is not a file, it's inline code
             if (array_key_exists('code', $config)) {


### PR DESCRIPTION
While working with Fluid AssetCollecter, we noticed that external scripts were added or rather processed twice.

If an external script was embedded with the f:asset ViewHelper, the script was loaded once as "script-min.js.gz" and once as "script-min.js-min.gz.gz" in the frontend.

After some testing and turning off and on other extensions and TypoScript settings, this simple fix helped.