### PR TITLE
[BUGFIX] if request is not set an error is thrown

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -26,7 +26,7 @@ plugin.tx_min.tinysource {
 }
 
 # This disables all features of EXT:min and also the compression and concatenation features of the core itself
-[backend.user.isLoggedIn && traverse(request.getQueryParams(), 'debug') > 0]
+[backend.user.isLoggedIn && request && traverse(request.getQueryParams(), 'debug') > 0]
 	plugin.tx_min.tinysource.enable = 0
 	config {
 		linkVars := addToList(debug(1))


### PR DESCRIPTION
If the request ist not set typo3 throws an error if this condition is evaluated we have to check that the request exists