### PR TITLE
[BUGFIX] Fix runtime exception, if setup does not exist in $frontendTypoScript

### DIFF
--- a/Classes/EventListener/AssetRendererEventListener.php
+++ b/Classes/EventListener/AssetRendererEventListener.php
@@ -27,7 +27,7 @@ class AssetRendererEventListener
     {
         $this->minifier = $minifier;
         $frontendTypoScript = $GLOBALS['TYPO3_REQUEST']->getAttribute('frontend.typoscript');
-        if ($frontendTypoScript instanceof FrontendTypoScript) {
+        if ($frontendTypoScript instanceof FrontendTypoScript && $frontendTypoScript->hasSetup()) {
             $this->assetCollectorConf = $frontendTypoScript->getSetupArray()['plugin.']['tx_min.']['assetCollector.'] ?? [];
         }
     }


### PR DESCRIPTION
$frontendTypoScript->getSetupArray() can cause a runtime exception, as it does not exist in every case. 
Also see here: 
https://forge.typo3.org/issues/99417

This PR avoids the runtime exception by calling hasSetup() to check, if the setup already has been initialized.