### PR TITLE
Allow skipping minification per asset via data-min-skip attribute

### DIFF
--- a/Classes/EventListener/AssetRendererEventListener.php
+++ b/Classes/EventListener/AssetRendererEventListener.php
@@ -123,6 +123,11 @@ class AssetRendererEventListener
                 continue;
             }
 
+            // Skip compression when asset has data-min-skip attribute (e.g. from f:asset.css data-min-skip="1")
+            if (!empty($asset['attributes']['data-min-skip'])) {
+                continue;
+            }
+            
             if ($event->isInline()) {
                 $assets[$uniqueIdentifier] = [
                     'compress' => true,


### PR DESCRIPTION
## Description

### Summary

Assets that carry a `data-min-skip` attribute (e.g. `data-min-skip="1"`) are no longer minified. They are left unchanged and rendered as registered with the AssetCollector. This allows excluding single CSS/JS files from minification without disabling compression globally.

### Motivation

Minification can break assets that rely on relative URLs resolved from the original file path. For example, Leaflet’s CSS references marker images with `url(images/marker-icon.png)`. After EXT:min writes minified CSS to a new path, the browser resolves these URLs against that path and the images return 404. There is no built-in way to exclude individual assets. This change adds a simple opt-out via an attribute that is already passed through by TYPO3’s Asset ViewHelpers (`f:asset.css`, `f:asset.script`) into the collector’s `attributes` array.

### Implementation

- In `AssetRendererEventListener::buildMinifierAssetsArray()`, before adding an asset to the minifier list, the code checks `$asset['attributes']['data-min-skip']`. If it is set (e.g. to `"1"`), the asset is skipped (`continue`) and not added to `$assets`, so it is never minified and is rendered as-is.
- No changes to TYPO3 core or to the Asset ViewHelpers are required. Authors add the attribute in templates, e.g.:
  - `<f:asset.css identifier="leaflet" href="EXT:my_ext/Resources/Public/Vendor/leaflet/leaflet.css" data-min-skip="1" />`
  - `<f:asset.script identifier="leaflet" src="EXT:my_ext/Resources/Public/Vendor/leaflet/leaflet.js" data-min-skip="1" />`

### Testing

- Enable EXT:min with CSS/JS compression.
- Register a stylesheet that uses relative URLs (e.g. Leaflet CSS) with `data-min-skip="1"`.
- Verify the asset is included in the page but not minified (original path, relative URLs still work).
- Verify other assets without the attribute are still minified.

### Backward compatibility

Fully backward compatible: existing installations are unchanged; the new behaviour only applies when the attribute is set.